### PR TITLE
Adding listeners for post-execution of stop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.bettershards</groupId>
 	<artifactId>BetterShards</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.20</version>
+	<version>1.3.21</version>
 	<name>BetterShards</name>
 	<url>https://github.com/Civcraft/BetterShards</url>
 

--- a/src/vg/civcraft/mc/bettershards/listeners/BetterShardsListener.java
+++ b/src/vg/civcraft/mc/bettershards/listeners/BetterShardsListener.java
@@ -2,6 +2,7 @@ package vg.civcraft.mc.bettershards.listeners;
 
 import java.util.UUID;
 import java.util.logging.Level;
+import java.util.Collection;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -23,6 +24,8 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent
+import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.material.Bed;
 
 import vg.civcraft.mc.bettershards.BetterShardsAPI;
@@ -96,6 +99,30 @@ public class BetterShardsListener implements Listener{
 		db.playerQuitServer(uuid);
 		if (plugin.isPlayerInTransit(uuid))
 			return;
+	}
+	
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void consoleStopEvent(ServerCommandEvent event) {
+		if (event.getCommand().equals("stop") || event.getCommand().equals("/stop")) {
+			forcePlayerSave();
+		}
+	}
+	
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void opStopEvent(PlayerCommandPreprocessEvent event) {
+		if (event.getPlayer() != null && event.getPlayer().isOp() && (event.getMessage().equals("stop") || event.getMessage().equals("/stop") ) ) {
+			forcePlayerSave();
+		}
+	}
+	
+	/**
+	 * Forces all player save. Should be tied to low-priority event listeners (so they get called first) surrounding /stop.
+	 **/
+	private void forcePlayerSave() {
+		Collection<Player> online = Bukkit.getOnlinePlayers();
+		for (Player p : online) {
+			st.save(p);
+		}
 	}
 	
 	@EventHandler(priority = EventPriority.MONITOR)


### PR DESCRIPTION
First stab at forcing player data save on server shutdown, as the standard MC process apparently skips some players sometimes.
