### PR TITLE
Add teleportation commands

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -14,6 +14,8 @@ commands:
   permission: bettershards.*
  bse:
   permission: bettershards.*
+ tp:
+  permission: bettershards.*
 permissions:
   bettershards.*:
    default: op

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,8 @@ commands:
   permission: bettershards.*
  tp:
   permission: bettershards.*
+ ts:
+  permission: bettershards.*
 permissions:
   bettershards.*:
    default: op

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.bettershards</groupId>
 	<artifactId>BetterShards</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.55</version>
+	<version>1.3.56</version>
 	<name>BetterShards</name>
 	<url>https://github.com/Civcraft/BetterShards</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.bettershards</groupId>
 	<artifactId>BetterShards</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.54</version>
+	<version>1.3.55</version>
 	<name>BetterShards</name>
 	<url>https://github.com/Civcraft/BetterShards</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.bettershards</groupId>
 	<artifactId>BetterShards</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.6</version>
+	<version>1.3.61</version>
 	<name>BetterShards</name>
 	<url>https://github.com/Civcraft/BetterShards</url>
 

--- a/src/vg/civcraft/mc/bettershards/BetterShardsAPI.java
+++ b/src/vg/civcraft/mc/bettershards/BetterShardsAPI.java
@@ -124,7 +124,7 @@ public class BetterShardsAPI {
 	 * @param info- Use the format 'uuid server world x y z'
 	 * world can be either the world name or world uuid.
 	 */
-	public static void teleportPlayer(String info) {
-		mercManager.teleportPlayer(info);
+	public static void teleportPlayer(String server, String info) {
+		mercManager.teleportPlayer(server, info);
 	}
 }

--- a/src/vg/civcraft/mc/bettershards/BetterShardsAPI.java
+++ b/src/vg/civcraft/mc/bettershards/BetterShardsAPI.java
@@ -36,6 +36,18 @@ public class BetterShardsAPI {
 	}
 	
 	/**
+	 * Teleports a player to a different shard.
+	 * @param p The UUID of the Player that you wish to connect.
+	 * @param serverName The name of the server that you wish the player to be sent to.
+	 * @param reason The reason to be identified by the PlayerChangeServerEvent triggered by this method.
+	 * @throws PlayerStillDeadException If the player is dead than this exception is thrown. There are issues with trying
+	 * to teleport a dead player.  If calling from PlayerRespawnEvent just schedule a sync method to occur after the event.
+	 */
+	public static boolean connectPlayer(UUID p, String serverName, PlayerChangeServerReason reason) throws PlayerStillDeadException {
+		return plugin.teleportPlayerToServer(p, serverName, reason);
+	}
+	
+	/**
 	 * Teleports the specified player to the current server.
 	 * @param uuid The name of said player.
 	 */

--- a/src/vg/civcraft/mc/bettershards/BetterShardsPlugin.java
+++ b/src/vg/civcraft/mc/bettershards/BetterShardsPlugin.java
@@ -23,6 +23,7 @@ import net.minecraft.server.v1_8_R3.WorldServer;
 
 import org.apache.commons.io.IOUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
@@ -175,6 +176,16 @@ public class BetterShardsPlugin extends ACivMod{
 		out.writeUTF(server);
 		p.sendPluginMessage(this, "BungeeCord", out.toByteArray());
 		return true;
+	}
+	
+	public boolean teleportPlayerToServer(UUID playerUUID, String server, PlayerChangeServerReason reason) throws PlayerStillDeadException {
+		//Get the server of the player
+		String currentServer = MercuryAPI.getServerforAccount(playerUUID).getServerName();
+		if(currentServer == null){
+			return false;
+		}
+		MercuryAPI.sendMessage(currentServer, "teleport|connect|" + playerUUID + "|" + server + "|" + reason, "BetterShards");
+		return false;
 	}
 	
 	public DatabaseManager getDatabaseManager() {

--- a/src/vg/civcraft/mc/bettershards/command/BetterCommandHandler.java
+++ b/src/vg/civcraft/mc/bettershards/command/BetterCommandHandler.java
@@ -5,6 +5,7 @@ import vg.civcraft.mc.bettershards.command.commands.DeletePortal;
 import vg.civcraft.mc.bettershards.command.commands.ExcludeServer;
 import vg.civcraft.mc.bettershards.command.commands.JoinPortal;
 import vg.civcraft.mc.bettershards.command.commands.RemovePortal;
+import vg.civcraft.mc.bettershards.command.commands.Teleport;
 import vg.civcraft.mc.civmodcore.command.CommandHandler;
 
 public class BetterCommandHandler extends CommandHandler{
@@ -16,6 +17,7 @@ public class BetterCommandHandler extends CommandHandler{
 		addCommands(new ExcludeServer("ExcludeServer"));
 		addCommands(new JoinPortal("JoinPortal"));
 		addCommands(new RemovePortal("RemovePortal"));
+		addCommands(new Teleport("Teleport"));
 	}
 
 }

--- a/src/vg/civcraft/mc/bettershards/command/BetterCommandHandler.java
+++ b/src/vg/civcraft/mc/bettershards/command/BetterCommandHandler.java
@@ -6,6 +6,7 @@ import vg.civcraft.mc.bettershards.command.commands.ExcludeServer;
 import vg.civcraft.mc.bettershards.command.commands.JoinPortal;
 import vg.civcraft.mc.bettershards.command.commands.RemovePortal;
 import vg.civcraft.mc.bettershards.command.commands.Teleport;
+import vg.civcraft.mc.bettershards.command.commands.TeleportServer;
 import vg.civcraft.mc.civmodcore.command.CommandHandler;
 
 public class BetterCommandHandler extends CommandHandler{
@@ -18,6 +19,7 @@ public class BetterCommandHandler extends CommandHandler{
 		addCommands(new JoinPortal("JoinPortal"));
 		addCommands(new RemovePortal("RemovePortal"));
 		addCommands(new Teleport("Teleport"));
+		addCommands(new TeleportServer("TeleportServer"));
 	}
 
 }

--- a/src/vg/civcraft/mc/bettershards/command/commands/Teleport.java
+++ b/src/vg/civcraft/mc/bettershards/command/commands/Teleport.java
@@ -134,7 +134,7 @@ public class Teleport extends PlayerCommand {
 		Player targetPlayer = Bukkit.getPlayer(targetPlayerUUID);
 		if (targetPlayer != null) {
 			//Stage teleport on current server
-			MercuryListener.stageTeleport(targetPlayerUUID, targetPlayer.getLocation());		
+			MercuryListener.stageTeleport(PlayerUUID, targetPlayer.getLocation());		
 		} else {
 			//Stage teleport on destination server
 			mercManager.teleportPlayer(serverName, PlayerUUID, targetPlayerUUID);

--- a/src/vg/civcraft/mc/bettershards/command/commands/Teleport.java
+++ b/src/vg/civcraft/mc/bettershards/command/commands/Teleport.java
@@ -152,11 +152,11 @@ public class Teleport extends PlayerCommand {
 	public List<String> tabComplete(CommandSender sender, String[] args) {
 		if (args.length <= 2) {
 			List<String> namesToReturn = new ArrayList<String>();
-			Set<String> players = MercuryAPI.instance.getAllPlayers();
+			Set<String> players = MercuryAPI.getAllPlayers();
 			if (args.length == 2)
 				players.remove(args[0]);
 			for (String x : players) {
-				if (x.toLowerCase().startsWith(args[0].toLowerCase()))
+				if (x.toLowerCase().startsWith(args[args.length-1].toLowerCase()))
 					namesToReturn.add(x);
 			}
 			return namesToReturn;
@@ -164,7 +164,8 @@ public class Teleport extends PlayerCommand {
 		if(args.length >= 4){
 			List<String> worldsToReturn = new ArrayList<String>();
 			for(World world : Bukkit.getWorlds()){
-				worldsToReturn.add(world.getName());
+				if (world.getName().toLowerCase().startsWith(args[args.length-1].toLowerCase()))
+					worldsToReturn.add(world.getName());
 			}
 			return worldsToReturn;
 		}

--- a/src/vg/civcraft/mc/bettershards/command/commands/Teleport.java
+++ b/src/vg/civcraft/mc/bettershards/command/commands/Teleport.java
@@ -45,9 +45,9 @@ public class Teleport extends PlayerCommand {
 			return true;
 		}
 		if (args.length == 1)
-			return playerTeleport(sender, args);
+			return playerTeleport(sender, args[0]);
 		else if (args.length == 2)
-			return playerToPlayerTeleport(sender, args);
+			return playerTeleport(sender, args[0], args[1]);
 		else if (args.length == 3)
 			return cordsTeleport(sender, args);
 		else if (args.length == 4)
@@ -58,8 +58,8 @@ public class Teleport extends PlayerCommand {
 			return false;
 		}
 	}
-
-	private boolean playerTeleport(CommandSender sender, String[] args) {
+	
+	public boolean playerTeleport(CommandSender sender, String targetPlayerName) {
 		if (!(sender instanceof Player)) {
 			sender.sendMessage("You must be a player to execute this command. "
 					+ "What do you expect, teleporting the console to a Location...");
@@ -67,15 +67,15 @@ public class Teleport extends PlayerCommand {
 		}
 		Player p = (Player)sender;
 		
-		//Player is on the same server
-		Player other = Bukkit.getPlayer(args[0]);
+		//Check if the players are on the same server
+		Player other = Bukkit.getPlayer(targetPlayerName);
 		if (other != null) {
 			p.teleport(other);
 			return true;
 		}
 		
-		//Player is on a different server
-		UUID targetPlayerUUID = NameAPI.getUUID(args[0]);
+		//Target player is on a different server. Get the UUID of the target Player.
+		UUID targetPlayerUUID = NameAPI.getUUID(targetPlayerName);
 		if(targetPlayerUUID == null){
 			sender.sendMessage(ChatColor.RED + "Player does not exist.");
 			return true;
@@ -101,14 +101,16 @@ public class Teleport extends PlayerCommand {
 		return true;
 	}
 	
-	private boolean playerToPlayerTeleport(CommandSender sender, String[] args) {
-		UUID PlayerUUID = NameAPI.getUUID(args[0]);
-		if(PlayerUUID == null){
-			sender.sendMessage(ChatColor.RED + "Player does not exist.");
+	public boolean playerTeleport(CommandSender sender, String playerName, String targetPlayerName) {
+		//Check if the player is on the current server
+		Player player = Bukkit.getPlayer(playerName);
+		if(player != null){
+			playerTeleport(player, targetPlayerName);
 			return true;
 		}
 		
-		UUID targetPlayerUUID = NameAPI.getUUID(args[1]);
+		//Get the UUID of the target player
+		UUID targetPlayerUUID = NameAPI.getUUID(targetPlayerName);
 		if(targetPlayerUUID == null){
 			sender.sendMessage(ChatColor.RED + "Target player does not exist.");
 			return true;
@@ -121,10 +123,10 @@ public class Teleport extends PlayerCommand {
 			return true;
 		}
 		
-		//Check if the player is on the current server
-		Player player = Bukkit.getPlayer(PlayerUUID);
-		if(player != null){
-			playerTeleport(player, new String[]{args[1]});
+		//Get the UUID of the player
+		UUID PlayerUUID = NameAPI.getUUID(playerName);
+		if(PlayerUUID == null){
+			sender.sendMessage(ChatColor.RED + "Player does not exist.");
 			return true;
 		}
 		
@@ -154,7 +156,7 @@ public class Teleport extends PlayerCommand {
 			List<String> namesToReturn = new ArrayList<String>();
 			Set<String> players = MercuryAPI.getAllPlayers();
 			if (args.length == 2)
-				players.remove(args[0]);
+				players.remove(args[0]); //Can't teleport to yourself
 			for (String x : players) {
 				if (x.toLowerCase().startsWith(args[args.length-1].toLowerCase()))
 					namesToReturn.add(x);
@@ -179,6 +181,7 @@ public class Teleport extends PlayerCommand {
 					+ "What do you expect, teleporting the console to a Location...");
 			return true;
 		}
+		
 		Player p = (Player)sender;
 		World w = p.getLocation().getWorld();
 		int x, y, z;
@@ -190,20 +193,21 @@ public class Teleport extends PlayerCommand {
 			p.sendMessage(ChatColor.RED + "Please make sure you entered the cords correctly.");
 			return true;
 		}
+		
 		Location newLocation = new Location(w, x, y, z);
 		p.teleport(newLocation);
 		return true;
 	}
 	
-	// Format for args world, x, y, x
+	// Format for args x, y, z, world
 	private boolean worldTeleport(CommandSender sender, String[] args) {
 		if (!(sender instanceof Player)) {
 			sender.sendMessage("You must be a player to execute this command. "
 					+ "What do you expect, teleporting the console to a Location...");
 			return true;
 		}
-		
 		Player p = (Player)sender;
+		
 		World w = Bukkit.getWorld(args[3]);
 		if (w == null) {
 			p.sendMessage(ChatColor.RED + "That world does not exist.");
@@ -225,6 +229,7 @@ public class Teleport extends PlayerCommand {
 		return true;
 	}
 	
+	// Format for args player, x, y, z, world
 	private boolean playerWorldTeleport(CommandSender sender, String[] args) {	
 		Player p = Bukkit.getPlayer(args[0]);
 		if (p == null) {
@@ -252,34 +257,4 @@ public class Teleport extends PlayerCommand {
 		p.teleport(newLoc);
 		return true;
 	}
-	
-	// Format for args server, world, x, y, z
-/*	private boolean serverTeleport(CommandSender p, String[] args) {
-		try {
-			Integer.parseInt(args[0]);
-			Integer.parseInt(args[1]);
-			Integer.parseInt(args[2]);
-		} catch(NumberFormatException e) {
-			p.sendMessage(ChatColor.RED + "Please make sure you entered the cords correctly.");
-			return true;
-		}
-		String server = args[0];
-		if (!MercuryAPI.getAllConnectedServers().contains(server)) {
-			p.sendMessage(ChatColor.RED + "Sorry that server is not connected to the network.");
-			return true;
-		}
-		StringBuilder message = new StringBuilder();
-		message.append(p.getUniqueId().toString() + " ");
-		for (int x = 1; x < args.length; x++) {
-			message.append(args[x] + " ");
-		}
-		try {
-			BetterShardsAPI.connectPlayer(p, server, PlayerChangeServerReason.TP_COMMAND);
-		} catch (PlayerStillDeadException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		mercManager.teleportPlayer(message.toString());
-		return true;
-	}*/
 }

--- a/src/vg/civcraft/mc/bettershards/command/commands/TeleportServer.java
+++ b/src/vg/civcraft/mc/bettershards/command/commands/TeleportServer.java
@@ -1,0 +1,35 @@
+package vg.civcraft.mc.bettershards.command.commands;
+
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+
+import vg.civcraft.mc.bettershards.BetterShardsPlugin;
+import vg.civcraft.mc.bettershards.external.MercuryManager;
+import vg.civcraft.mc.civmodcore.command.PlayerCommand;
+
+public class TeleportServer extends PlayerCommand{
+	private MercuryManager mercManager = BetterShardsPlugin.getMercuryManager();
+
+	public TeleportServer(String name) {
+		super(name);
+		setIdentifier("ts");
+		setDescription("Teleports you to another server");
+		setUsage("/ts <server>\n"
+				+ "/ts <server> <x> <y> <z>\n"
+				+ "/ts <server> <x> <y> <z> <world>");
+		setArguments(1, 5);
+	}
+
+	@Override
+	public boolean execute(CommandSender arg0, String[] arg1) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender arg0, String[] arg1) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+}

--- a/src/vg/civcraft/mc/bettershards/command/commands/TeleportServer.java
+++ b/src/vg/civcraft/mc/bettershards/command/commands/TeleportServer.java
@@ -85,9 +85,9 @@ public class TeleportServer extends PlayerCommand{
 	// Format for args server, x, y, z, world
 	private boolean serverTeleport(Player p, String[] args) {
 		try {
-			Integer.parseInt(args[0]);
 			Integer.parseInt(args[1]);
 			Integer.parseInt(args[2]);
+			Integer.parseInt(args[3]);
 		} catch(NumberFormatException e) {
 			p.sendMessage(ChatColor.RED + "Please make sure you entered the cords correctly.");
 			return true;

--- a/src/vg/civcraft/mc/bettershards/command/commands/TeleportServer.java
+++ b/src/vg/civcraft/mc/bettershards/command/commands/TeleportServer.java
@@ -1,12 +1,20 @@
 package vg.civcraft.mc.bettershards.command.commands;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
+import vg.civcraft.mc.bettershards.BetterShardsAPI;
 import vg.civcraft.mc.bettershards.BetterShardsPlugin;
+import vg.civcraft.mc.bettershards.events.PlayerChangeServerReason;
 import vg.civcraft.mc.bettershards.external.MercuryManager;
+import vg.civcraft.mc.bettershards.misc.PlayerStillDeadException;
 import vg.civcraft.mc.civmodcore.command.PlayerCommand;
+import vg.civcraft.mc.mercury.MercuryAPI;
 
 public class TeleportServer extends PlayerCommand{
 	private MercuryManager mercManager = BetterShardsPlugin.getMercuryManager();
@@ -22,14 +30,88 @@ public class TeleportServer extends PlayerCommand{
 	}
 
 	@Override
-	public boolean execute(CommandSender arg0, String[] arg1) {
-		// TODO Auto-generated method stub
-		return false;
+	public boolean execute(CommandSender sender, String[] args) {
+		if (!(sender.hasPermission("BetterShards.admin") || sender.isOp())) {
+			sender.sendMessage(ChatColor.RED + "You must have permission or be an admin to execute this command.");
+			return true;
+		}
+		
+		if (!(sender instanceof Player)) {
+			sender.sendMessage("You must be a player to execute this command. "
+					+ "What do you expect, teleporting the console to a server...");
+			return true;
+		}
+		Player p = (Player)sender;
+		
+		if(args.length == 1){
+			serverTeleport(p, args[0]);
+		} else if(args.length == 4 || args.length == 5){
+			serverTeleport(p, args);
+		} else { 
+			return false;
+		}
+		return true;
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender arg0, String[] arg1) {
-		// TODO Auto-generated method stub
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (args.length == 1) {
+			List<String> serversToReturn = new ArrayList<String>();
+			Set<String> servers = MercuryAPI.getAllConnectedServers();
+			for (String x : servers) {
+				if (x.toLowerCase().startsWith(args[0].toLowerCase()))
+					serversToReturn.add(x);
+			}
+			return serversToReturn;
+		}
 		return null;
+	}
+	
+	private boolean serverTeleport(Player p, String serverName){
+		if(!MercuryAPI.getAllConnectedServers().contains(serverName)){
+			p.sendMessage(ChatColor.RED + "Sorry that server is not connected to the network.");
+			return true;
+		}
+		
+		try {
+			BetterShardsAPI.connectPlayer(p, serverName, PlayerChangeServerReason.TP_COMMAND);
+		} catch (PlayerStillDeadException e) {
+			p.sendMessage(ChatColor.RED + "You cant switch server when you are dead");
+		}
+		
+		return true;
+	}
+	
+	// Format for args server, x, y, z, world
+	private boolean serverTeleport(Player p, String[] args) {
+		try {
+			Integer.parseInt(args[0]);
+			Integer.parseInt(args[1]);
+			Integer.parseInt(args[2]);
+		} catch(NumberFormatException e) {
+			p.sendMessage(ChatColor.RED + "Please make sure you entered the cords correctly.");
+			return true;
+		}
+		
+		String server = args[0];
+		if (!MercuryAPI.getAllConnectedServers().contains(server)) {
+			p.sendMessage(ChatColor.RED + "Sorry that server is not connected to the network.");
+			return true;
+		}
+		
+		if(args.length == 4){
+			mercManager.teleportPlayer(server ,p.getUniqueId(), args[1], args[2], args[3]);
+		} else if(args.length == 5){
+			mercManager.teleportPlayer(server ,p.getUniqueId(), args[1], args[2], args[3], args[4]);
+		}
+		
+		try {
+			BetterShardsAPI.connectPlayer(p, server, PlayerChangeServerReason.TP_COMMAND);
+		} catch (PlayerStillDeadException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		return true;
 	}
 }

--- a/src/vg/civcraft/mc/bettershards/external/MercuryManager.java
+++ b/src/vg/civcraft/mc/bettershards/external/MercuryManager.java
@@ -44,6 +44,18 @@ public class MercuryManager {
 	public void teleportPlayer(String info) {
 		MercuryAPI.sendGlobalMessage("teleport|command|" + info , "BetterShards");
 	}
+	
+	public void teleportPlayer(String server, UUID playerToTeleportUUID, UUID targetPlayerUUID) {
+		MercuryAPI.sendMessage(server, "teleport|command|" + playerToTeleportUUID + "|" + targetPlayerUUID , "BetterShards");
+	}
+	
+	public void teleportPlayer(String server, UUID playerToTeleportUUID, int x, int y, int z) {
+		MercuryAPI.sendMessage(server, "teleport|command|" + playerToTeleportUUID + "|" + x + "|" + y +"|" + z , "BetterShards");
+	}
+	
+	public void teleportPlayer(String server, UUID playerToTeleportUUID, int x, int y, int z, String world) {
+		MercuryAPI.sendMessage(server, "teleport|command|" + playerToTeleportUUID + "|" + x + "|" + y +"|" + z + "|" + world, "BetterShards");
+	}
 
 	private void registerMercuryChannels() {
 		MercuryAPI.addChannels("BetterShards");

--- a/src/vg/civcraft/mc/bettershards/external/MercuryManager.java
+++ b/src/vg/civcraft/mc/bettershards/external/MercuryManager.java
@@ -38,23 +38,23 @@ public class MercuryManager {
 
 	/**
 	 * Sends the info to servers that a player needs to be teleported.
-	 * @param info- Use the format 'uuid server world x y z'
+	 * @param info- Use the format 'uuid world x y z'
 	 * world can be either the world name or world uuid.
 	 */
-	public void teleportPlayer(String info) {
-		MercuryAPI.sendGlobalMessage("teleport|command|" + info , "BetterShards");
+	public void teleportPlayer(String server, String info) {
+		MercuryAPI.sendMessage(server, "teleport|command|" + info , "BetterShards");
 	}
 	
 	public void teleportPlayer(String server, UUID playerToTeleportUUID, UUID targetPlayerUUID) {
 		MercuryAPI.sendMessage(server, "teleport|command|" + playerToTeleportUUID + "|" + targetPlayerUUID , "BetterShards");
 	}
 	
-	public void teleportPlayer(String server, UUID playerToTeleportUUID, int x, int y, int z) {
+	public void teleportPlayer(String server, UUID playerToTeleportUUID, String x, String y, String z) {
 		MercuryAPI.sendMessage(server, "teleport|command|" + playerToTeleportUUID + "|" + x + "|" + y +"|" + z , "BetterShards");
 	}
 	
-	public void teleportPlayer(String server, UUID playerToTeleportUUID, int x, int y, int z, String world) {
-		MercuryAPI.sendMessage(server, "teleport|command|" + playerToTeleportUUID + "|" + x + "|" + y +"|" + z + "|" + world, "BetterShards");
+	public void teleportPlayer(String server, UUID playerToTeleportUUID, String x, String y, String z, String world) {
+		MercuryAPI.sendMessage(server, "teleport|command|" + playerToTeleportUUID + "|" + world + "|" + x + "|" + y +"|" + z, "BetterShards");
 	}
 
 	private void registerMercuryChannels() {

--- a/src/vg/civcraft/mc/bettershards/listeners/BetterShardsListener.java
+++ b/src/vg/civcraft/mc/bettershards/listeners/BetterShardsListener.java
@@ -212,12 +212,12 @@ public class BetterShardsListener implements Listener{
 			});
 			return;
 		}
-		final String info = bed.getUUID().toString() + " " + bed.getLocation();
+		final String info = bed.getUUID().toString() + "|" + bed.getLocation();
 		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
 
 			@Override
 			public void run() {
-				mercManager.teleportPlayer(info);
+				mercManager.teleportPlayer(bed.getServer(), bed.getServer());
 				try {
 					BetterShardsAPI.connectPlayer(p, bed.getServer(), PlayerChangeServerReason.BED);
 				} catch (PlayerStillDeadException e) {

--- a/src/vg/civcraft/mc/bettershards/listeners/MercuryListener.java
+++ b/src/vg/civcraft/mc/bettershards/listeners/MercuryListener.java
@@ -17,10 +17,13 @@ import vg.civcraft.mc.bettershards.BetterShardsAPI;
 import vg.civcraft.mc.bettershards.BetterShardsPlugin;
 import vg.civcraft.mc.bettershards.PortalsManager;
 import vg.civcraft.mc.bettershards.events.PlayerArrivedChangeServerEvent;
+import vg.civcraft.mc.bettershards.events.PlayerChangeServerReason;
 import vg.civcraft.mc.bettershards.misc.BedLocation;
+import vg.civcraft.mc.bettershards.misc.PlayerStillDeadException;
 import vg.civcraft.mc.bettershards.portal.Portal;
 import vg.civcraft.mc.bettershards.portal.portals.WorldBorderPortal;
 import vg.civcraft.mc.mercury.events.AsyncPluginBroadcastMessageEvent;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class MercuryListener implements Listener{
 	
@@ -71,11 +74,16 @@ public class MercuryListener implements Listener{
 					else if (action.equals("command")) {
 						uuid = UUID.fromString(content[2]);
 						Location loc = null;
-						try {
-							loc = new Location(Bukkit.getWorld(UUID.fromString(content[3])), Integer.parseInt(content[4]), Integer.parseInt(content[5]), Integer.parseInt(content[6]));
-						} catch(IllegalArgumentException e) {
-							// The world uuid is none existent so it must be a world name.
+						if(content.length == 4){
+							Player targetPlayer = Bukkit.getPlayer(UUID.fromString(content[3]));
+							loc = targetPlayer.getLocation();
+						} else { 
+							try {
+								loc = new Location(Bukkit.getWorld(UUID.fromString(content[3])), Integer.parseInt(content[4]), Integer.parseInt(content[5]), Integer.parseInt(content[6]));
+							} catch(IllegalArgumentException e) {
+								// The world uuid is none existent so it must be a world name.
 							loc = new Location(Bukkit.getWorld(content[3]), Integer.parseInt(content[4]), Integer.parseInt(content[5]), Integer.parseInt(content[6]));
+							}
 						}
 						uuids.put(uuid, loc);
 					}
@@ -83,7 +91,17 @@ public class MercuryListener implements Listener{
 						Location loc = plugin.getRandomSpawn().getLocation();
 						uuid =UUID.fromString(content[2]);		
 						uuids.put(uuid, loc);
-						
+					}
+					else if (action.equals("connect")){
+						Player player = Bukkit.getPlayer(UUID.fromString(content[2]));
+						if(player != null){
+							try {
+								BetterShardsAPI.connectPlayer(player, content[3], PlayerChangeServerReason.valueOf(content[4]));
+							} catch (PlayerStillDeadException e) {
+								// TODO Auto-generated catch block
+								e.printStackTrace();
+							}
+						}
 					}
 					
 					Player p = Bukkit.getPlayer(uuid);

--- a/src/vg/civcraft/mc/bettershards/listeners/MercuryListener.java
+++ b/src/vg/civcraft/mc/bettershards/listeners/MercuryListener.java
@@ -39,7 +39,7 @@ public class MercuryListener implements Listener{
 		if (!channel.equals(c))
 			return;
 		String message = event.getMessage();
-		final String[] content = message.split(" ");
+		final String[] content = message.split("\\|");
 		if (content[0].equals("delete")) {
 			Portal p = pm.getPortal(content[1]);
 			if (p != null)
@@ -170,6 +170,9 @@ public class MercuryListener implements Listener{
 		}
 	}
 	
+	public static void stageTeleport(UUID uuid, Location loc){
+		uuids.put(uuid, loc);
+	}
 	public static Location getTeleportLocation(UUID uuid) {
 		Location loc = uuids.get(uuid);
 		uuids.remove(uuid);

--- a/src/vg/civcraft/mc/bettershards/listeners/MercuryListener.java
+++ b/src/vg/civcraft/mc/bettershards/listeners/MercuryListener.java
@@ -77,12 +77,14 @@ public class MercuryListener implements Listener{
 						if(content.length == 4){
 							Player targetPlayer = Bukkit.getPlayer(UUID.fromString(content[3]));
 							loc = targetPlayer.getLocation();
-						} else { 
+						} else if(content.length == 6){
+								loc = new Location(Bukkit.getWorlds().get(0), Integer.parseInt(content[3]), Integer.parseInt(content[4]), Integer.parseInt(content[5]));
+						} else if(content.length == 7){
 							try {
 								loc = new Location(Bukkit.getWorld(UUID.fromString(content[3])), Integer.parseInt(content[4]), Integer.parseInt(content[5]), Integer.parseInt(content[6]));
 							} catch(IllegalArgumentException e) {
 								// The world uuid is none existent so it must be a world name.
-							loc = new Location(Bukkit.getWorld(content[3]), Integer.parseInt(content[4]), Integer.parseInt(content[5]), Integer.parseInt(content[6]));
+								loc = new Location(Bukkit.getWorld(content[3]), Integer.parseInt(content[4]), Integer.parseInt(content[5]), Integer.parseInt(content[6]));
 							}
 						}
 						uuids.put(uuid, loc);


### PR DESCRIPTION
/tp is used to teleport a player to another player or a specific location on the map. Teleporting between players works between shards.
Usages:
- /tp <player> 
- /tp <player> <player> (can be used on consol)
- /tp <x> <y> <z>
- /tp <x> <y> <z> <world>
- /tp <player> <x> <y> <z> <world> (can be used on consol)

/ts is used to switch a server in-game
Usages:
- /ts <server>
- /ts <server> <x> <y> <z>
- /ts <server> <x> <y> <z> <world>
