### PR TITLE
comment out a line setting the reconnect server of a player in the Se…

### DIFF
--- a/BetterShardsBukkit/pom.xml
+++ b/BetterShardsBukkit/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>vg.civcraft.mc.bettershards</groupId>
 		<artifactId>BetterShardsParent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.40</version>
 	</parent>
 
 	<artifactId>BetterShardsBukkit</artifactId>

--- a/BetterShardsBukkit/pom.xml
+++ b/BetterShardsBukkit/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>vg.civcraft.mc.bettershards</groupId>
 		<artifactId>BetterShardsParent</artifactId>
-		<version>1.4.39</version>
+		<version>1.4.4</version>
 	</parent>
 
 	<artifactId>BetterShardsBukkit</artifactId>

--- a/BetterShardsBungee/pom.xml
+++ b/BetterShardsBungee/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>vg.civcraft.mc.bettershards</groupId>
 		<artifactId>BetterShardsParent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.40</version>
 	</parent>
 
 	<artifactId>BetterShardsBungee</artifactId>

--- a/BetterShardsBungee/pom.xml
+++ b/BetterShardsBungee/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>vg.civcraft.mc.bettershards</groupId>
 		<artifactId>BetterShardsParent</artifactId>
-		<version>1.4.39</version>
+		<version>1.4.4</version>
 	</parent>
 
 	<artifactId>BetterShardsBungee</artifactId>

--- a/BetterShardsBungee/src/main/java/vg/civcraft/mc/bettershards/bungee/BungeeListener.java
+++ b/BetterShardsBungee/src/main/java/vg/civcraft/mc/bettershards/bungee/BungeeListener.java
@@ -134,7 +134,7 @@ public class BungeeListener implements Listener, EventListener {
 			return;
 		}
 		
-		player.setReconnectServer(kickedFrom);
+		//player.setReconnectServer(kickedFrom);
 		event.setCancelled(true);
 		event.setCancelServer(ProxyServer.getInstance().getServerInfo(lobbyServer));
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.bettershards</groupId>
 	<artifactId>BetterShardsParent</artifactId>
 	<packaging>pom</packaging>
-	<version>1.4.39</version>
+	<version>1.4.4</version>
 	<name>BetterShards</name>
 	<url>https://github.com/Civcraft/BetterShards/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.bettershards</groupId>
 	<artifactId>BetterShardsParent</artifactId>
 	<packaging>pom</packaging>
-	<version>1.4.4</version>
+	<version>1.4.40</version>
 	<name>BetterShards</name>
 	<url>https://github.com/Civcraft/BetterShards/</url>
 


### PR DESCRIPTION
This was causing the server of a player to not be changed in the database if he did not logout after being moved to the lobby. Safe to remove since we have a check in the ReconnectHandler to not save the lobby as the server of a player.
