### PR TITLE
Fix location persistence

### DIFF
--- a/BetterShardsBukkit/pom.xml
+++ b/BetterShardsBukkit/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>jar</packaging>
 	<name>BetterShards</name>
 	<url>https://github.com/Civcraft/BetterShards</url>
-	<version>1.4.50</version>
+	<version>1.4.53</version>
 
 
     <build>

--- a/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/listeners/BetterShardsListener.java
+++ b/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/listeners/BetterShardsListener.java
@@ -48,6 +48,7 @@ import vg.civcraft.mc.bettershards.events.PlayerChangeServerReason;
 import vg.civcraft.mc.bettershards.external.MercuryManager;
 import vg.civcraft.mc.bettershards.manager.PortalsManager;
 import vg.civcraft.mc.bettershards.manager.RandomSpawnManager;
+import vg.civcraft.mc.bettershards.manager.TransitManager;
 import vg.civcraft.mc.bettershards.misc.BedLocation;
 import vg.civcraft.mc.bettershards.misc.CustomWorldNBTStorage;
 import vg.civcraft.mc.bettershards.misc.Grid;
@@ -163,8 +164,15 @@ public class BetterShardsListener implements Listener{
 		Player p = event.getPlayer();
 		UUID uuid = p.getUniqueId();
 		db.playerQuitServer(uuid);
-		if (!BetterShardsPlugin.getTransitManager().isPlayerInTransit(uuid)) {
-			st.save(p, st.getInvIdentifier(uuid), true);
+		TransitManager tm = BetterShardsPlugin.getTransitManager();
+		if (tm.isPlayerInArrivalTransit(uuid)) {
+			//quitting while in arrival transit. We dont allow the player to save his inventory in this state, but we need to keep his location
+			MercuryListener.stageTeleport(uuid, p.getLocation());
+		}
+		else {
+			if (!BetterShardsPlugin.getTransitManager().isPlayerInTransit(uuid)) {
+				st.save(p, st.getInvIdentifier(uuid), true);
+			}
 		}
 	}
 	

--- a/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/manager/ConnectionManager.java
+++ b/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/manager/ConnectionManager.java
@@ -63,7 +63,7 @@ public class ConnectionManager {
 	 * @param server The server to teleport the player to.
 	 */
 	public boolean teleportPlayerToServer(Player p, String server, PlayerChangeServerReason reason) throws PlayerStillDeadException {
-		if (transitManager.isPlayerInExitTransit(p.getUniqueId())) { // Somehow this got triggered twice for one reason or another
+		if (transitManager.isPlayerInTransit(p.getUniqueId())) { // Somehow this got triggered twice for one reason or another
 				return false; // We dont wan't to continue twice because it could cause issues with the db.
 		}
 		PlayerChangeServerEvent event = new PlayerChangeServerEvent(reason, p.getUniqueId(), server);

--- a/BetterShardsBungee/pom.xml
+++ b/BetterShardsBungee/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>BetterShardsBungee</artifactId>
 	<packaging>jar</packaging>
 	<name>BetterShards</name>
-	<version>1.4.52</version>
+	<version>1.4.53</version>
 
 	<build>
 		<resources>

--- a/BetterShardsBungee/src/main/java/vg/civcraft/mc/bettershards/bungee/BungeeListener.java
+++ b/BetterShardsBungee/src/main/java/vg/civcraft/mc/bettershards/bungee/BungeeListener.java
@@ -164,8 +164,9 @@ public class BungeeListener implements Listener, EventListener {
 
 	@Override
 	public void receiveMessage(String origin, String channel, String message) {
-		if (!channel.equals("BetterShards"))
+		if (!channel.equals("BetterShards")) {
 			return;
+		}
 		String[] content = message.split("\\|");
 		if (content[0].equals("count")) {
 			BetterShardsBungee.setServerCount(origin, Integer.parseInt(content[1]));


### PR DESCRIPTION
This fixes the issue we talked about earlier today. Player location will be persisted even if the player data isn't saved due to transit. Additionally we will disallow sending a player to another server while he's in arrival transit, not only during exit transit (should have done this from the beginning).
