### PR TITLE
Adding back in (carefully) pre-join player inventory load cache. 

### DIFF
--- a/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/listeners/BetterShardsListener.java
+++ b/BetterShardsBukkit/src/main/java/vg/civcraft/mc/bettershards/listeners/BetterShardsListener.java
@@ -89,18 +89,18 @@ public class BetterShardsListener implements Listener{
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void playerPreLoginCacheInv(AsyncPlayerPreLoginEvent event) {
 		UUID uuid = event.getUniqueId();
-		/*if (uuid != null) {
+		if (uuid != null) {
 			plugin.getLogger().log(Level.FINER, "Preparing to pre-load player data: {0}", uuid);
 		} else { 
 			return;
-		}*/
+		}
 		if (st == null){ // Small race condition if someone logs on as soon as the server starts.
 			event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER, "Please try to log in again in a moment, server is not ready to accept log-ins.");
 			plugin.getLogger().log(Level.INFO, "Player {0} logged on before async process was ready, skipping.", uuid);
 			return;
 		}
 		// caching disabled due to fail
-		/*Future<ByteArrayInputStream> soondata = db.loadPlayerDataAsync(uuid, st.getInvIdentifier(uuid)); // wedon't use the data, but know that it caches behind the scenes.
+		Future<ByteArrayInputStream> soondata = db.loadPlayerDataAsync(uuid, st.getInvIdentifier(uuid), true); // wedon't use the data, but know that it caches behind the scenes.
 		
 		try {
 			ByteArrayInputStream after = soondata.get(); // I want to _INTENTIONALLY_ delay accepting the user's login until I know for sure I've got the data loaded asynchronously.
@@ -113,7 +113,7 @@ public class BetterShardsListener implements Listener{
 		} catch (InterruptedException | ExecutionException e) {
 			plugin.getLogger().log(Level.SEVERE, "Failed to pre-load player data: {0}", uuid);
 			e.printStackTrace();
-		}*/
+		}
 		
 		// We do this so it fetches the cache, then when called for real
 		// by our CustomWorldNBTStorage class it doesn't have to wait and server won't lock.


### PR DESCRIPTION
Cache is short lived and prefers to expire. Nothing else uses it, and it only gets filled if explicitly requested, which in this case only occurs in the prejoin async event. Then, post-join the normal inventory minecraft load will access the cache, which clears it.
